### PR TITLE
ci: auto-update Homebrew formula on new releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,3 +76,84 @@ jobs:
 
       - name: Upload release assets
         run: gh release upload "${{ github.ref_name }}" createos-* --clobber
+
+  update-homebrew:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SHA256 files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION_NUM="${VERSION#v}"
+          BASE="https://github.com/NodeOps-app/createos-cli/releases/download/${VERSION}"
+
+          for target in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64; do
+            curl -sL "${BASE}/createos-${target}.sha256" > "sha256-${target}.txt"
+          done
+
+          SHA_DARWIN_ARM64=$(cat sha256-darwin-arm64.txt)
+          SHA_DARWIN_AMD64=$(cat sha256-darwin-amd64.txt)
+          SHA_LINUX_ARM64=$(cat sha256-linux-arm64.txt)
+          SHA_LINUX_AMD64=$(cat sha256-linux-amd64.txt)
+
+          cat > createos.rb << FORMULA
+          class Createos < Formula
+            desc "CreateOS CLI - Deploy APIs, manage infrastructure, and monetize Skills"
+            homepage "https://github.com/NodeOps-app/createos-cli"
+            version "${VERSION_NUM}"
+            license "MIT"
+
+            on_macos do
+              on_arm do
+                url "https://github.com/NodeOps-app/createos-cli/releases/download/v#{version}/createos-darwin-arm64"
+                sha256 "${SHA_DARWIN_ARM64}"
+              end
+
+              on_intel do
+                url "https://github.com/NodeOps-app/createos-cli/releases/download/v#{version}/createos-darwin-amd64"
+                sha256 "${SHA_DARWIN_AMD64}"
+              end
+            end
+
+            on_linux do
+              on_arm do
+                url "https://github.com/NodeOps-app/createos-cli/releases/download/v#{version}/createos-linux-arm64"
+                sha256 "${SHA_LINUX_ARM64}"
+              end
+
+              on_intel do
+                url "https://github.com/NodeOps-app/createos-cli/releases/download/v#{version}/createos-linux-amd64"
+                sha256 "${SHA_LINUX_AMD64}"
+              end
+            end
+
+            def install
+              binary = Dir["createos-*"].first || "createos"
+              bin.install binary => "createos"
+            end
+
+            test do
+              assert_match "createos", shell_output("#{bin}/createos version 2>&1")
+            end
+          end
+          FORMULA
+
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' createos.rb
+
+      - name: Push to Homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          git clone https://x-access-token:${GH_TOKEN}@github.com/NodeOps-app/homebrew-createos.git tap
+          cp createos.rb tap/Formula/createos.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/createos.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "Update createos to ${VERSION}"
+          git push


### PR DESCRIPTION
## Summary

Adds an `update-homebrew` job to the release workflow so that every time a new version is tagged (`v*`), the Homebrew formula at `NodeOps-app/homebrew-createos` is automatically updated with the new version and SHA256 hashes.

## How it works

1. Release workflow builds binaries + SHA256 files (existing)
2. New `update-homebrew` job runs after `release` job completes
3. Downloads the 4 SHA256 files (darwin-arm64, darwin-amd64, linux-arm64, linux-amd64)
4. Generates an updated `Formula/createos.rb` with new version + hashes
5. Pushes to `NodeOps-app/homebrew-createos`

## Setup required

Add a `HOMEBREW_TAP_TOKEN` secret to the `createos-cli` repo:
- Create a GitHub PAT (fine-grained) with `contents: write` permission on `NodeOps-app/homebrew-createos`
- Add it as a repo secret: Settings → Secrets → Actions → `HOMEBREW_TAP_TOKEN`

## Test plan

- [ ] Create `HOMEBREW_TAP_TOKEN` secret
- [ ] Tag a test release (e.g., `v0.0.4`)
- [ ] Verify `homebrew-createos/Formula/createos.rb` is auto-updated
- [ ] `brew upgrade createos` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)