### PR TITLE
fix(sandbox): update default URLs to prod endpoints

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -67,7 +67,7 @@ func NewApp() *cli.App {
 				Name:    "sandbox-gateway",
 				Usage:   "SSH gateway address (<host:port>) used by `sandbox shell`",
 				EnvVars: []string{"CREATEOS_SANDBOX_GATEWAY"},
-				Value:   "65.109.104.247:2222",
+				Value:   "gateway.sb.createos.sh:2222",
 			},
 			&cli.StringFlag{
 				Name:    "output",

--- a/internal/api/sandbox_client.go
+++ b/internal/api/sandbox_client.go
@@ -8,7 +8,7 @@ import (
 // sandbox surface lives on a different host from the main CreateOS API
 // (api-createos.nodeops.network); these two clients are wired
 // side-by-side under app.Metadata.
-const DefaultSandboxBaseURL = "https://fc-spawn.bhautik.in"
+const DefaultSandboxBaseURL = "https://api.sb.createos.sh"
 
 // SandboxClient wraps a resty.Client configured for the fc-spawn API.
 // Mirrors APIClient but targets the sandbox base URL and uses
@@ -72,4 +72,4 @@ func newSandboxClient(authHeader, token, sandboxURL string, debug bool, refreshe
 }
 
 // SandboxClientKey is the cli.Context metadata key for the sandbox client.
-const SandboxClientKey = "sandbox_client"
+const SandboxClientKey = "sandbox_client" // #nosec G101 -- context metadata key, not a credential  // pragma: allowlist secret


### PR DESCRIPTION
## Summary

- `DefaultSandboxBaseURL`: `fc-spawn.bhautik.in` → `api.sb.createos.sh`
- `sandbox-gateway` default: `65.109.104.247:2222` → `gateway.sb.createos.sh:2222`

## Test plan

- [ ] `createos sandbox list` hits correct API endpoint
- [ ] `createos sandbox shell <id>` connects via correct gateway host