### PR TITLE
chore: ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude
 .createos.json
+.env
 .env.*
 cos
 build.sh


### PR DESCRIPTION
Bare `.env` wasn't ignored — `.gitignore` only had `.env.*`, which doesn't match `.env`. Add it so local env files stay untracked.