### PR TITLE
ci: move GitHub-hosted jobs to createos runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   lint-and-test:
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: createos
     steps:
       - name: checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: build (${{ matrix.goos }}-${{ matrix.goarch }})
-    runs-on: ubuntu-latest
+    runs-on: createos
     strategy:
       matrix:
         include:
@@ -61,7 +61,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: createos
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   build:
     name: build (${{ matrix.goos }}-${{ matrix.goarch }})
-    runs-on: ubuntu-latest
+    runs-on: createos
     strategy:
       matrix:
         include:
@@ -61,7 +61,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: createos
     env:
       GH_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
Moves every remaining `runs-on: ubuntu-latest` job in this repo to the `createos` label, so it runs on the CreateOS ephemeral microVM runners (`createos-sandbox-ghar`) instead of billable GitHub-hosted Linux runners.

Only the `runs-on` line changes — no other workflow edits.

The CI on this PR is itself the verification: if these checks go green, the jobs work on the new runner.

Runner image parity with `ubuntu-latest`: docker + buildx + compose, `gh`, git, jq, python3, gcc/g++/make, zstd/zip/xz, and a writable `/opt/hostedtoolcache` so `actions/setup-*` works. Shape is `s-4vcpu-4gb` (bare `createos` label); switch a job to `createos-8vcpu-8gb` if it needs more.